### PR TITLE
Use dill to load the composite metric

### DIFF
--- a/CXRMetric/run_eval.py
+++ b/CXRMetric/run_eval.py
@@ -3,7 +3,7 @@ import numpy as np
 import os
 import re
 import pandas as pd
-import pickle
+import dill
 import torch
 
 from bert_score import BERTScorer
@@ -204,9 +204,9 @@ def calc_metric(gt_csv, pred_csv, out_csv, use_idf): # TODO: support single metr
 
     # compute composite metric: RadCliQ-v0
     with open(COMPOSITE_METRIC_V0_PATH, "rb") as f:
-        composite_metric_v0_model = pickle.load(f)
+        composite_metric_v0_model = dill.load(f)
     with open(NORMALIZER_PATH, "rb") as f:
-        normalizer = pickle.load(f)
+        normalizer = dill.load(f)
     # normalize
     input_data = np.array(pred[COLS])
     norm_input_data = normalizer.transform(input_data)
@@ -216,7 +216,7 @@ def calc_metric(gt_csv, pred_csv, out_csv, use_idf): # TODO: support single metr
 
     # compute composite metric: RadCliQ-v1
     with open(COMPOSITE_METRIC_V1_PATH, "rb") as f:
-        composite_metric_v1_model = pickle.load(f)
+        composite_metric_v1_model = dill.load(f)
     input_data = np.array(pred[COLS])
     radcliq_v1_scores = composite_metric_v1_model.predict(input_data)
     pred[composite_metric_col_v1] = radcliq_v1_scores

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ allennlp==1.1.0
 allennlp_models==1.1.0
 beautifulsoup4==4.8.1
 bert-score==0.3.11
+dill==0.3.8
 fast-bleu==0.0.90
 lxml
 numpy==1.18.2


### PR DESCRIPTION
Seems to fix this for me
```
composite_metric_v1_model = pickle.load(f)
*** AttributeError: Can't get attribute 'CompositeMetric' on <module 'main'>
```
https://github.com/rajpurkarlab/CXR-Report-Metric/issues/2